### PR TITLE
[FEAT] 카테고리 정보 저장 API 개발

### DIFF
--- a/src/main/java/com/nz/nomadzip/client/tourapi/adapter/TourApiAdapter.java
+++ b/src/main/java/com/nz/nomadzip/client/tourapi/adapter/TourApiAdapter.java
@@ -1,5 +1,6 @@
 package com.nz.nomadzip.client.tourapi.adapter;
 
+import com.nz.nomadzip.client.tourapi.dto.CategoryResponse;
 import com.nz.nomadzip.client.tourapi.dto.RegionResponse;
 import com.nz.nomadzip.client.tourapi.port.TourApiPort;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +14,7 @@ public class TourApiAdapter implements TourApiPort {
     private final WebClient webClient;
 
     @Override
-    public RegionResponse getAreaCodes(int numOfRows) {
+    public RegionResponse getAreaCode(int numOfRows) {
         RegionResponse regionResponse = webClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/areaCode2")
@@ -39,5 +40,21 @@ public class TourApiAdapter implements TourApiPort {
                 .bodyToMono(RegionResponse.class)
                 .block();
         return childRegionResponse;
+    }
+
+    @Override
+    public CategoryResponse getCategory(String categoryCode, int depth) {
+        CategoryResponse categoryResponse = webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/lclsSystmCode2")    // 분류체계코드조회
+                        .queryParam("numOfRows", 1000)
+                        .queryParam("lclsSystm" + depth, categoryCode)
+                        .queryParam("lclsSystmListYn", 'Y')
+                        .build()
+                )
+                .retrieve()
+                .bodyToMono(CategoryResponse.class)
+                .block();
+        return categoryResponse;
     }
 }

--- a/src/main/java/com/nz/nomadzip/client/tourapi/dto/CategoryResponse.java
+++ b/src/main/java/com/nz/nomadzip/client/tourapi/dto/CategoryResponse.java
@@ -1,0 +1,24 @@
+package com.nz.nomadzip.client.tourapi.dto;
+
+import java.util.List;
+
+public record CategoryResponse(Response response) {
+
+    public record Response(Header header, Body body) {}
+
+    // Header
+    public record Header(String resultCode, String resultMsg) {}
+
+    // Body
+    public record Body(Items items, int numOfRows, int pageNo, int totalCount) {}
+
+    // Items
+    public record Items(List<Item> item) {}
+
+    // 실제 데이터
+    public record Item(String lclsSystm1Cd, String lclsSystm1Nm,
+                       String lclsSystm2Cd, String lclsSystm2Nm,
+                       String lclsSystm3Cd, String lclsSystm3Nm,
+                       int rnum) {}
+
+}

--- a/src/main/java/com/nz/nomadzip/client/tourapi/port/TourApiPort.java
+++ b/src/main/java/com/nz/nomadzip/client/tourapi/port/TourApiPort.java
@@ -1,9 +1,13 @@
 package com.nz.nomadzip.client.tourapi.port;
 
+import com.nz.nomadzip.client.tourapi.dto.CategoryResponse;
 import com.nz.nomadzip.client.tourapi.dto.RegionResponse;
 
 public interface TourApiPort {
-    RegionResponse getAreaCodes(int numOfRows);
+    RegionResponse getAreaCode(int numOfRows);
 
     RegionResponse getAreaCode(String parentAreaCode, int numOfRows);
+
+    CategoryResponse getCategory(String categoryCode, int depth);
+
 }

--- a/src/main/java/com/nz/nomadzip/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/nz/nomadzip/common/exception/GlobalExceptionHandler.java
@@ -33,11 +33,11 @@ public class GlobalExceptionHandler {
 
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleException() {
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         ErrorCode errorCode = GlobalErrorCode.INTERNAL_SERVER_ERROR;
 
         ApiResponse<Void> response = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
-
+        e.printStackTrace();
         return new ResponseEntity<>(response, errorCode.getHttpStatus());
     }
 

--- a/src/main/java/com/nz/nomadzip/spot/command/application/controller/SpotCommandController.java
+++ b/src/main/java/com/nz/nomadzip/spot/command/application/controller/SpotCommandController.java
@@ -14,9 +14,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class SpotCommandController {
     private final SpotCommandService spotCommandService;
 
+    /* 지역 정보 초기 채우기용 */
     @GetMapping("/region")
     public ResponseEntity<ApiResponse<Void>> fetchRegion(){
         spotCommandService.fetchRegion();
+
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @GetMapping("/category")
+    public ResponseEntity<ApiResponse<Void>> fetchCategory(){
+        spotCommandService.fetchCategory();
 
         return ResponseEntity.ok(ApiResponse.success(null));
     }

--- a/src/main/java/com/nz/nomadzip/spot/command/application/mapper/CategoryMapper.java
+++ b/src/main/java/com/nz/nomadzip/spot/command/application/mapper/CategoryMapper.java
@@ -1,0 +1,31 @@
+package com.nz.nomadzip.spot.command.application.mapper;
+
+
+import com.nz.nomadzip.client.tourapi.dto.CategoryResponse;
+import com.nz.nomadzip.spot.command.domain.entity.Category;
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+        componentModel = "spring",
+        unmappedSourcePolicy = ReportingPolicy.ERROR    // 매핑 안된 요소 에러 발생!
+//        unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
+public interface CategoryMapper {
+    @Mapping(source = "item.lclsSystm1Cd", target = "categoryCode")
+    @Mapping(source = "item.lclsSystm1Nm", target = "categoryName")
+    @BeanMapping(ignoreUnmappedSourceProperties = {"lclsSystm2Cd", "lclsSystm2Nm", "lclsSystm3Cd", "lclsSystm3Nm", "rnum"})
+    Category toDepth1CategoryEntity(CategoryResponse.Item item);
+
+    @Mapping(source = "item.lclsSystm2Cd", target = "categoryCode")
+    @Mapping(source = "item.lclsSystm2Nm", target = "categoryName")
+    @BeanMapping(ignoreUnmappedSourceProperties = {"lclsSystm1Cd", "lclsSystm1Nm", "lclsSystm3Cd", "lclsSystm3Nm", "rnum"})
+    Category toDepth2CategoryEntity(CategoryResponse.Item item);
+
+    @BeanMapping(ignoreUnmappedSourceProperties = {"lclsSystm1Cd", "lclsSystm1Nm", "lclsSystm2Cd", "lclsSystm2Nm", "rnum"})
+    @Mapping(source = "item.lclsSystm3Cd", target = "categoryCode")
+    @Mapping(source = "item.lclsSystm3Nm", target = "categoryName")
+    Category toDepth3CategoryEntity(CategoryResponse.Item item);
+}

--- a/src/main/java/com/nz/nomadzip/spot/command/application/service/SpotCommandService.java
+++ b/src/main/java/com/nz/nomadzip/spot/command/application/service/SpotCommandService.java
@@ -1,32 +1,42 @@
 package com.nz.nomadzip.spot.command.application.service;
 
+import com.nz.nomadzip.client.tourapi.dto.CategoryResponse;
 import com.nz.nomadzip.client.tourapi.dto.RegionResponse;
 import com.nz.nomadzip.client.tourapi.port.TourApiPort;
+import com.nz.nomadzip.common.exception.BusinessException;
+import com.nz.nomadzip.spot.command.application.mapper.CategoryMapper;
 import com.nz.nomadzip.spot.command.application.mapper.RegionMapper;
+import com.nz.nomadzip.spot.command.domain.entity.Category;
 import com.nz.nomadzip.spot.command.domain.entity.Region;
+import com.nz.nomadzip.spot.command.domain.repository.CategoryRepository;
 import com.nz.nomadzip.spot.command.domain.repository.RegionRepository;
+import com.nz.nomadzip.spot.exception.SpotErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 @RequiredArgsConstructor
 @Service
 @Slf4j
 public class SpotCommandService {
     private final RegionRepository regionRepository;
+    private final CategoryRepository categoryRepository;
     private final TourApiPort tourApi;
     private final RegionMapper regionMapper;
+    private final CategoryMapper categoryMapper;
+    private final WebClient webClient;
 
     @Transactional
     public void fetchRegion() {
         List<Region> regionList = new ArrayList<>();    // 최종 저장 시 사용할 지역 배열
 
         // 부모 지역 호출
-        RegionResponse parentRegions = tourApi.getAreaCodes(100);
+        RegionResponse parentRegions = tourApi.getAreaCode(100);
 
         // 부모 지역 repository 저장하기
 
@@ -42,5 +52,74 @@ public class SpotCommandService {
         }
 
         regionRepository.saveAll(regionList);
+    }
+
+    @Transactional
+    public void fetchCategory() {
+        Map<String, Category> parentCategoryMap = new HashMap<>();
+        Map<String, Category> childCategoryMap = new HashMap<>();
+
+        /* 초기 설정 카테고리 목록*/
+        final List<InitCategory> initCategoryList = List.of(
+                new InitCategory("EV01", 2), // 축제
+                new InitCategory("EX",   1), // 체험 관광
+                new InitCategory("HS",   1), // 역사 관광
+                new InitCategory("NA",   1), // 자연 관광
+                new InitCategory("VE",   1)  // 문화 관광
+        );
+        // 1. 카테고리 api 호출
+        for(InitCategory category: initCategoryList){
+            CategoryResponse categoryCodes = tourApi.getCategory(category.categoryCode, category.depth);
+
+            for(CategoryResponse.Item item : categoryCodes.response().body().items().item()){
+                Category parentCategory = null;
+                Category childCategory = null;
+                // case 1: depth가 1인 경우
+                if(category.depth == 1){
+                    parentCategory = categoryMapper.toDepth1CategoryEntity(item);
+                    childCategory = categoryMapper.toDepth2CategoryEntity(item);
+                }
+
+                // case 2: depth가 2인 경우
+                if(category.depth == 2){
+                    parentCategory = categoryMapper.toDepth2CategoryEntity(item);
+                    childCategory = categoryMapper.toDepth3CategoryEntity(item);
+                }
+
+                if(parentCategory != null && childCategory != null){
+                    // 임시 연결
+                    childCategory.setParentCategory(parentCategory);
+                    parentCategoryMap.put(parentCategory.getCategoryCode(), parentCategory);
+                    childCategoryMap.put(childCategory.getCategoryCode(), childCategory);
+                }
+            }
+        }
+        try{
+            // 부모와 자식을 나눠서 save하는 방식으로 영속성 지키기!
+            categoryRepository.saveAll(parentCategoryMap.values());
+
+            List<Category> childCategoryList = childCategoryMap.values().stream()
+                            .map(category -> {
+                                Category parentCategory = categoryRepository
+                                        .findByCategoryCode(category.getParentCategory().getCategoryCode());
+                                category.setParentCategory(parentCategory);
+                                return category;
+                            }).toList();
+
+            categoryRepository.saveAll(childCategoryList);
+        }catch(DataIntegrityViolationException e){
+            throw new BusinessException(SpotErrorCode.DUPLICATE_DATA_ERROR);
+        }
+    }
+
+    /* 초기 저장으로 사용할 카테고리를 위한 클래스! */
+    private static class InitCategory{
+        String categoryCode;
+        int depth;
+
+        InitCategory(String categoryCode, int depth){
+            this.categoryCode = categoryCode;
+            this.depth = depth;
+        }
     }
 }

--- a/src/main/java/com/nz/nomadzip/spot/command/domain/entity/Category.java
+++ b/src/main/java/com/nz/nomadzip/spot/command/domain/entity/Category.java
@@ -12,7 +12,7 @@ import lombok.*;
 public class Category {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long categoryId;
 
 

--- a/src/main/java/com/nz/nomadzip/spot/command/domain/entity/Category.java
+++ b/src/main/java/com/nz/nomadzip/spot/command/domain/entity/Category.java
@@ -1,0 +1,32 @@
+package com.nz.nomadzip.spot.command.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name="category")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long categoryId;
+
+
+    @Column(unique = true)
+    private String categoryCode;
+
+    private String categoryName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_category_id")
+    Category parentCategory;
+
+    // 부모 카테고리 명시적 작성을 위해 Lombok 미사용!
+    public void setParentCategory(Category parentCategory){
+        this.parentCategory = parentCategory;
+    }
+}

--- a/src/main/java/com/nz/nomadzip/spot/command/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/nz/nomadzip/spot/command/domain/repository/CategoryRepository.java
@@ -1,0 +1,8 @@
+package com.nz.nomadzip.spot.command.domain.repository;
+
+import com.nz.nomadzip.spot.command.domain.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    Category findByCategoryCode(String categoryCode);
+}

--- a/src/main/java/com/nz/nomadzip/spot/exception/SpotErrorCode.java
+++ b/src/main/java/com/nz/nomadzip/spot/exception/SpotErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 public enum SpotErrorCode implements ErrorCode {
     /* ????? 에러코드 할당 */
+    DUPLICATE_DATA_ERROR("90001", "같은 데이터가 이미 존재합니다.", HttpStatus.BAD_REQUEST),
     ERROR_CODE("에러 코드 입력", "에러 메시지 입력", HttpStatus.NOT_FOUND);
 
     private final String code;


### PR DESCRIPTION
### 작업 목적/배경

Tour API 기준에 맞는 카테고리 정보 저장을 위한 엔드포인트 개발

### 할 일(체크리스트)

- [x] Tour API 카테고리 호출 로직 개발
- [x] mapStruct를 통한 api response <-> entity 매핑
- [x] JPA를 활용한 DB 저장
- [x] 동일 카테고리 저장 시 에러 처리

<img width="714" height="296" alt="image" src="https://github.com/user-attachments/assets/e3751164-22bf-4845-88c4-2d0fbe4fbe08" />